### PR TITLE
Configure logging options

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,10 +45,29 @@ source venv/bin/activate
 pip3 install -r requirements.txt
 ```
 
-3. Copy `config.example.py` to `config.py` and enter your Postgres credentials. 
+3. Copy `config.example.py` to `config.py` and enter your Postgres credentials. See Config section below for info on
+   logging options.
 4. Run `python3 create_tables.py` to set up the database. (Alternatively, restore the database from a recent DB dump).
 
 Now you can run `python3 collect.py` to start collecting data.
+
+
+### Config
+
+The example config file is set up for logging to the terminal (using the `coloredlogs` package for pretty formatting).
+If you want to log to a file instead, you can set the `handler` to `file` and configure the path to the log file and
+the format you want to use. An example is below:
+```
+    "logging": {
+        "level": logging.DEBUG,
+        "handler": "file",
+        "format": "%(asctime)s [%(process)d:%(thread)d] %(levelname)-8s %(name)-30.30s %(message)s",
+        "file": "/path/to/log/file"
+    }
+```
+[See the Python module docs](https://docs.python.org/3/library/logging.html#logrecord-attributes) for more info on
+specifying the log format.
+
 
 ## Visualization frontend
 

--- a/blocking.py
+++ b/blocking.py
@@ -5,7 +5,6 @@
 
 
 import logging
-import coloredlogs
 import requests
 from time import sleep
 
@@ -13,16 +12,13 @@ from psycopg2.extensions import cursor
 from psycopg2.extensions import connection
 import pandas as pd
 
+from src.shared.utils import configure_logging
 
 # In[2]:
 
 
-logging.basicConfig()
+configure_logging()
 logger = logging.getLogger("poll-ooni")
-# logger.setLevel(logging.DEBUG)
-coloredlogs.install()
-coloredlogs.install(level='DEBUG')
-# coloredlogs.install(level='INFO')
 
 
 # In[40]:

--- a/collect.py
+++ b/collect.py
@@ -8,10 +8,10 @@
 import time
 import schedule
 import threading
-import psycopg2
 import logging
 import coloredlogs
 from funcy import partial
+from src.shared.utils import configure_logging
 
 
 
@@ -29,12 +29,8 @@ def run_threaded(job_func):
 #
 # setup
 #
-logging.basicConfig()
+configure_logging()
 logger = logging.getLogger("taaraxtak:collect")
-# logger.setLevel(logging.DEBUG)
-coloredlogs.install()
-coloredlogs.install(level='INFO')
-# coloredlogs.install(level='DEBUG')
 
 # connect to the db
 postgres_config = config['postgres']

--- a/collect.py
+++ b/collect.py
@@ -9,7 +9,6 @@ import time
 import schedule
 import threading
 import logging
-import coloredlogs
 from funcy import partial
 from src.shared.utils import configure_logging
 

--- a/config.example.py
+++ b/config.example.py
@@ -12,5 +12,7 @@ config = {
     "logging": {
         "level": logging.DEBUG,
         "handler": "terminal",
+        "format": "%(asctime)s [%(process)d:%(thread)d] %(levelname)-8s %(name)-30.30s %(message)s",
+        "file": "/path/to/log/file"
     }
 }

--- a/config.example.py
+++ b/config.example.py
@@ -11,8 +11,6 @@ config = {
     "tld_cache_dir": "/home/my-user/",
     "logging": {
         "level": logging.DEBUG,
-        "handler": "terminal",
-        "format": "%(asctime)s [%(process)d:%(thread)d] %(levelname)-8s %(name)-30.30s %(message)s",
-        "file": "/path/to/log/file"
+        "handler": "terminal"
     }
 }

--- a/config.example.py
+++ b/config.example.py
@@ -11,6 +11,6 @@ config = {
     "tld_cache_dir": "/home/my-user/",
     "logging": {
         "level": logging.DEBUG,
-        "file": False,
+        "handler": "terminal",
     }
 }

--- a/config.example.py
+++ b/config.example.py
@@ -1,3 +1,5 @@
+import logging
+
 config = {
     "postgres": {
         "user": "scraper",
@@ -6,5 +8,9 @@ config = {
         "port": "5432",
         "database": "my-database",
     },
-    "tld_cache_dir": "/home/my-user/"
+    "tld_cache_dir": "/home/my-user/",
+    "logging": {
+        "level": logging.DEBUG,
+        "file": False,
+    }
 }

--- a/create_tables.py
+++ b/create_tables.py
@@ -7,22 +7,18 @@
 
 from funcy import partial
 import logging
-import coloredlogs
 import psycopg2
 
 from src.w3techs.types import create_tables as w3techs_create
 from src.ooni.types import create_tables as ooni_create
 
 from config import config
+from src.shared.utils import configure_logging
 #
 # setup
 #
-logging.basicConfig()
+configure_logging()
 logger = logging.getLogger("taaraxtak:create_tables")
-# logger.setLevel(logging.DEBUG)
-coloredlogs.install()
-coloredlogs.install(level='INFO')
-# coloredlogs.install(level='DEBUG')
 
 # connect to the db
 connection = psycopg2.connect(**config['postgres'])

--- a/src/ooni/utils.py
+++ b/src/ooni/utils.py
@@ -38,7 +38,7 @@ from typing import Optional
 OONI_SLEEP_PAGINATE = 0.25
 
 
-logging.basicConfig()
+shared_utils.configure_logging()
 logger = logging.getLogger("src.ooni.utils")
 # logger.setLevel(logging.DEBUG)
 coloredlogs.install()

--- a/src/ooni/utils.py
+++ b/src/ooni/utils.py
@@ -1,5 +1,4 @@
 import logging
-import coloredlogs
 import requests
 from time import sleep
 from datetime import datetime
@@ -38,15 +37,7 @@ from typing import Optional
 OONI_SLEEP_PAGINATE = 0.25
 
 
-shared_utils.configure_logging()
 logger = logging.getLogger("src.ooni.utils")
-# logger.setLevel(logging.DEBUG)
-coloredlogs.install()
-coloredlogs.install(level='DEBUG')
-# coloredlogs.install(level='INFO')
-
-# disable noisy logging by filelock (called by TLDExtract to deal with its cache)
-logging.getLogger("filelock").setLevel(logging.ERROR)
 
 
 #

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -65,8 +65,10 @@ def configure_logging():
     logging_config = config['logging']
     log_level = logging_config['level']
     if logging_config['handler'] == 'file':
-        logging.basicConfig(level=log_level, filename=logging_config['file'])
+        logging.basicConfig(level=log_level, filename=logging_config['file'], format=logging_config['format'])
     else:
         logging.basicConfig(level=log_level)
         coloredlogs.install()
         coloredlogs.install(level=log_level)
+    # Schedule lib logs out params (including db creds) by default so set this to WARNING and above
+    logging.getLogger("schedule").setLevel(logging.WARNING)

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -72,3 +72,5 @@ def configure_logging():
         coloredlogs.install(level=log_level)
     # Schedule lib logs out params (including db creds) by default so set this to WARNING and above
     logging.getLogger("schedule").setLevel(logging.WARNING)
+    # disable noisy logging by filelock (called by TLDExtract to deal with its cache)
+    logging.getLogger("filelock").setLevel(logging.ERROR)

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -7,6 +7,8 @@ from datetime import datetime
 
 from typing import Optional
 
+from config import config
+import coloredlogs
 
 #
 # Time
@@ -57,3 +59,14 @@ def get_country(provider_name: str) -> Optional[str]:
     except (KeyError):
         logging.info(f'Cannot find country for {provider_name}')
         return None
+
+
+def configure_logging():
+    logging_config = config['logging']
+    log_level = logging_config['level']
+    if logging_config['file']:
+        logging.basicConfig(level=log_level, filename=logging_config['file'])
+    else:
+        logging.basicConfig(level=log_level)
+        coloredlogs.install()
+        coloredlogs.install(level=log_level)

--- a/src/shared/utils.py
+++ b/src/shared/utils.py
@@ -64,7 +64,7 @@ def get_country(provider_name: str) -> Optional[str]:
 def configure_logging():
     logging_config = config['logging']
     log_level = logging_config['level']
-    if logging_config['file']:
+    if logging_config['handler'] == 'file':
         logging.basicConfig(level=log_level, filename=logging_config['file'])
     else:
         logging.basicConfig(level=log_level)


### PR DESCRIPTION
I have added an option to configure logging to a file (and to be able to specify the format for this). This helps in our situation as we tend to log to a system-wide directory and from there harvest and aggregate our logs into a logging platform (e.g. ELK).

I have tried to keep the defaults (as specified in the example config file) the same as the current behaviour so that with any luck as long as you update your local config to match the example the current behaviour should not be affected.